### PR TITLE
group.create method looses parentId

### DIFF
--- a/src/modules/groupMethods.ts
+++ b/src/modules/groupMethods.ts
@@ -33,7 +33,7 @@ export const addCalculatedGroupFields = <T extends Group>(group: T, sessionUser?
 
 export const groupMethods = {
     create: (data: CreateGroup, sessionUser: SessionUser) => {
-        return prisma.group.create({ data: { supervisorId: sessionUser.id, name: data.name } });
+        return prisma.group.create({ data: { supervisorId: sessionUser.id, ...data } });
     },
 
     edit: async ({ groupId, ...data }: EditGroup) => {


### PR DESCRIPTION
## PR includes

-   [x] Bug Fix

## Related issues

Resolve #636
