### PR TITLE
Expand and fix history records for createUser and createGroup

### DIFF
--- a/src/components/HistoryRecord/HistoryRecord.tsx
+++ b/src/components/HistoryRecord/HistoryRecord.tsx
@@ -254,6 +254,7 @@ const componentMap: {
                         <ChangeListItem title={tr('Parent team id')} after={event.after.parentId} />
                         <ChangeListItem title={tr('Virtual team')} after={event.after.virtual} />
                         <ChangeListItem title={tr('Organizational team')} after={event.after.organizational} />
+                        <ChangeListItem title={tr('Supervisor id')} after={event.after.supervisorId} />
                     </>
                 ))}
             </>

--- a/src/modules/groupMethods.ts
+++ b/src/modules/groupMethods.ts
@@ -48,8 +48,8 @@ export const groupMethods = {
         return group;
     },
 
-    create: (data: CreateGroup, sessionUser: SessionUser) => {
-        return prisma.group.create({ data: { supervisorId: sessionUser.id, ...data } });
+    create: (data: CreateGroup, sessionUser?: SessionUser) => {
+        return prisma.group.create({ data: { supervisorId: sessionUser?.id, ...data } });
     },
 
     edit: async ({ groupId, ...data }: EditGroup) => {

--- a/src/modules/historyEventTypes.ts
+++ b/src/modules/historyEventTypes.ts
@@ -6,9 +6,9 @@ interface HistoryEventsData {
         data: {
             name?: string;
             email: string;
-            phone: string;
-            login: string;
-            organizationalUnitId: string;
+            phone?: string;
+            login?: string;
+            organizationalUnitId?: string;
             accountingId?: string;
             supervisorId?: string;
             createExternalAccount?: boolean;
@@ -111,6 +111,7 @@ interface HistoryEventsData {
             parentId?: string;
             virtual?: boolean;
             organizational?: boolean;
+            supervisorId?: string;
         };
     };
     editGroup: {

--- a/src/trpc/router/groupRouter.ts
+++ b/src/trpc/router/groupRouter.ts
@@ -36,6 +36,7 @@ export const groupRouter = router({
                 parentId: result.parentId || undefined,
                 virtual: result.virtual,
                 organizational: result.organizational,
+                supervisorId: result.supervisorId || undefined,
             },
         });
         return result;


### PR DESCRIPTION
All changes are backwards compatible with previous data

    required fields become optional in createUser
    new optional field is added in createGroup

## PR includes

-   [x] Refactor
-   [x] Feature

## Related issues

Resolve #939 

## QA Instructions, Screenshots, Recordings
